### PR TITLE
[WIP] Backport DRBD patch:

### DIFF
--- a/SOURCES/systemd-219-Backport-udev-exclude-DRBD-from-block-device-ownersh.XCP-ng.patch
+++ b/SOURCES/systemd-219-Backport-udev-exclude-DRBD-from-block-device-ownersh.XCP-ng.patch
@@ -1,0 +1,56 @@
+From a4621ae866977991eed65d143ffec525659c9a1b Mon Sep 17 00:00:00 2001
+From: Ronan Abhamon <ronan.abhamon@vates.fr>
+Date: Tue, 19 Apr 2022 11:04:51 +0200
+Subject: [PATCH] Backport: udev: exclude DRBD from block device ownership
+ event locking
+
+It does not make sense for udev to even open DRBD block devices
+(/dev/drbdX). It is on one hand not necessary as DRBD is controlled by
+something else in the stack (e.g., pacemaker), and it even can get
+cumbersome in various scenarios (e.g., DRBD9 auto-promote).
+
+Closes: systemd#9371
+
+Signed-off-by: Roland Kammerer <roland.kammerer@linbit.com>
+Signed-off-by: Lars Ellenberg <lars.ellenberg@linbit.com>
+---
+ src/udev/udevd.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/src/udev/udevd.c b/src/udev/udevd.c
+index 99d4c89..744be35 100644
+--- a/src/udev/udevd.c
++++ b/src/udev/udevd.c
+@@ -172,6 +172,18 @@ static void worker_list_cleanup(struct udev *udev) {
+         }
+ }
+ 
++static bool shall_lock_device(struct udev_device *dev) {
++        const char *sysname;
++
++        if (!streq_ptr("block", udev_device_get_subsystem(dev)))
++                return false;
++
++        sysname = udev_device_get_sysname(dev);
++        return !startswith(sysname, "dm-") &&
++               !startswith(sysname, "md") &&
++               !startswith(sysname, "drbd");
++}
++
+ static void worker_new(struct event *event) {
+         struct udev *udev = event->udev;
+         struct worker *worker;
+@@ -283,9 +295,7 @@ static void worker_new(struct event *event) {
+                          * udev has finished its event handling.
+                          */
+                         if (!streq_ptr(udev_device_get_action(dev), "remove") &&
+-                            streq_ptr("block", udev_device_get_subsystem(dev)) &&
+-                            !startswith(udev_device_get_sysname(dev), "dm-") &&
+-                            !startswith(udev_device_get_sysname(dev), "md")) {
++                            shall_lock_device(dev)) {
+                                 struct udev_device *d = dev;
+ 
+                                 if (streq_ptr("partition", udev_device_get_devtype(d)))
+-- 
+2.34.1
+

--- a/SPECS/systemd.spec
+++ b/SPECS/systemd.spec
@@ -7,7 +7,7 @@
 Name:           systemd
 Url:            http://www.freedesktop.org/wiki/Software/systemd
 Version:        219
-Release:        57.2%{?dist}
+Release:        57.3%{?dist}
 # For a breakdown of the licensing, see README
 License:        LGPLv2+ and MIT and GPLv2+
 Summary:        A System and Service Manager
@@ -661,6 +661,9 @@ Patch627: journal-disable-kmsg.patch
 Patch628: disable-acpi-events.patch
 Patch629: allow-tag-nomatch.patch
 Patch630: fix-mtd_probe-build.patch
+
+# XCP-ng patches
+Patch1000: systemd-219-Backport-udev-exclude-DRBD-from-block-device-ownersh.XCP-ng.patch
 
 Provides: gitsha(https://code.citrite.net/rest/archive/latest/projects/XSU/repos/systemd/archive?at=v219&format=tar.gz&prefix=systemd-219#/systemd-219.tar.gz) = a88abde72169ddc2df77df3fa5bed30725022253
 Provides: gitsha(https://code.citrite.net/rest/archive/latest/projects/XSU/repos/systemd.centos/archive?at=imports%2Fc7%2Fsystemd-219-57.el7_5.1&format=tar.gz#/systemd-219.centos.tar.gz) = 510b6a86d799463b360822320227d95ca008deb7
@@ -1665,6 +1668,9 @@ fi
 %{_mandir}/man8/systemd-resolved.*
 
 %changelog
+* Tue Apr 19 2022 Ronan Abhamon <ronan.abhamon@vates.fr> - 219-57.3
+- Add systemd-219-Backport-udev-exclude-DRBD-from-block-device-ownersh.XCP-ng.patch patch
+
 * Mon Jun 25 2018 Lukas Nykryn <lnykryn@redhat.com> - 219-57.1
 - umount: always use MNT_FORCE in umount_all() (#7213) (#1571098)
 - core: Implement timeout based umount/remount limit (#1571098)


### PR DESCRIPTION
"udev: exclude DRBD from block device ownership event locking"

Ensure DRBD is never open by systemd-udev, otherwise the device can be sometimes unusable.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>